### PR TITLE
Fix: Remove hardcoded API key from geminiService

### DIFF
--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,4 +1,5 @@
 import { ScriptLength, ScriptTone, ScriptType, GeneratedScriptResponse, GroundingChunk } from '../types';
+import { getApiKey } from '../services/envConfig';
 
 // Base URL for the Gemini API
 const GEMINI_API_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
@@ -11,7 +12,7 @@ const NEWS_API_BASE_URL = 'https://newsapi.org/v2';
 // Helper function to get API URL with key
 const getApiUrl = (): string => {
   // Use the new API key directly as requested
-  const apiKey = 'AIzaSyAkBSIMLzoQ7kioG75C4lXf1Ww_HjerGkk';
+  const apiKey = getApiKey();
   return `${GEMINI_API_BASE_URL}/${GEMINI_MODEL}:generateContent?key=${apiKey}`;
 };
 


### PR DESCRIPTION
I replaced the hardcoded API key in the `getApiUrl` function within `src/services/geminiService.ts` with a call to `getApiKey` from `src/services/envConfig.ts`.

This resolves a security vulnerability and allows the API key to be managed through environment variables as intended. I also verified that `app.js` correctly handles API key presence and validity.