### PR TITLE
Fix: Add message prop to LoadingSpinner

### DIFF
--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 
-const LoadingSpinner: React.FC = () => {
+interface LoadingSpinnerProps {
+  message?: string;
+}
+
+const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ message }) => {
   return (
-    <div className="flex justify-center items-center mt-8 mb-4">
+    <div className="flex flex-col justify-center items-center mt-8 mb-4">
       <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-neutral-800"></div>
+      {message && <p className="mt-4 text-neutral-600">{message}</p>}
     </div>
   );
 };


### PR DESCRIPTION
The LoadingSpinner component was being used with a `message` prop, but the component didn't define this prop, causing a TypeScript error.

This commit:
- Defines a `LoadingSpinnerProps` interface with an optional `message` string prop.
- Updates the `LoadingSpinner` component to accept `LoadingSpinnerProps`.
- Conditionally displays the `message` below the spinner if provided.