### PR TITLE
Fix: Correctly call unsubscribe on authListener subscription

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ const App: React.FC = () => {
     );
 
     return () => {
-      authListener?.unsubscribe();
+      authListener?.subscription?.unsubscribe();
     };
   }, []);
 


### PR DESCRIPTION
The `authListener` object returned by `supabase.auth.onAuthStateChange` contains a `subscription` property, which has the `unsubscribe` method. This commit fixes the TypeScript error by changing the call from `authListener?.unsubscribe()` to `authListener?.subscription?.unsubscribe()`.