### PR TITLE
Refactor: Remove BM_LABEL_ and BM_PLACEHOLDER_ prefixes from UI text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -334,7 +334,7 @@ const App: React.FC = () => {
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center">
               <Link to="/" className="text-white text-xl sm:text-2xl font-bold hover:opacity-90 transition-opacity">
-                BM_LABEL_AppName
+                AppName
               </Link>
             </div>
             <div className="hidden md:block">
@@ -343,20 +343,20 @@ const App: React.FC = () => {
                   to="/"
                   className="text-neutral-200 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
                 >
-                  BM_LABEL_GenerateScript
+                  GenerateScript
                 </Link>
                 <Link
                   to="/content-optimizer"
                   className="text-neutral-200 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
                 >
-                  BM_LABEL_OptimizeContent
+                  OptimizeContent
                 </Link>
                 {/* Placeholder for Proofread & Edit - adjust link as needed */}
                 <Link
                   to="/" // Assuming it links to a relevant page or main page for now
                   className="text-neutral-200 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
                 >
-                  BM_LABEL_ProofreadEdit
+                  ProofreadEdit
                 </Link>
               </div>
             </div>
@@ -382,7 +382,7 @@ const App: React.FC = () => {
       </div>
 
        <footer className="bg-neutral-800 text-neutral-300 p-4 text-center text-xs">
-        <p>BM_LABEL_Copyright &copy; {new Date().getFullYear()}</p>
+        <p>Copyright &copy; {new Date().getFullYear()}</p>
       </footer>
     </div>
   );

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -112,15 +112,15 @@ const LoginScreen: React.FC = () => {
     <div className="min-h-screen flex flex-col justify-center items-center bg-neutral-200 px-4 py-8">
       <div className="bg-white p-8 sm:p-10 rounded-xl shadow-2xl max-w-md w-full border border-neutral-300">
         <h1 className="text-3xl sm:text-4xl font-bold text-primary-dark text-center mb-8">
-          BM_LABEL_LoginWelcome
+          LoginWelcome
         </h1>
         <p className="mb-6 text-center text-neutral-600 text-sm sm:text-base">
-          {isForgotPassword ? 'BM_LABEL_ResetPasswordPrompt' : (isSignUp ? 'BM_LABEL_CreateAccountPrompt' : 'BM_LABEL_SignInPrompt')}
+          {isForgotPassword ? 'ResetPasswordPrompt' : (isSignUp ? 'CreateAccountPrompt' : 'SignInPrompt')}
         </p>
 
         <form onSubmit={isForgotPassword ? handlePasswordResetRequest : handleEmailPasswordAuth} className="space-y-6">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-neutral-700 mb-1">BM_LABEL_Email</label>
+            <label htmlFor="email" className="block text-sm font-medium text-neutral-700 mb-1">Email</label>
             <input
               type="email"
               id="email"
@@ -128,12 +128,12 @@ const LoginScreen: React.FC = () => {
               onChange={(e) => setEmail(e.target.value)}
               required
               className="w-full px-4 py-3 border border-neutral-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-shadow duration-150"
-              placeholder="BM_PLACEHOLDER_EnterEmail"
+              placeholder="EnterEmail"
             />
           </div>
           {!isForgotPassword && (
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-neutral-700 mb-1">BM_LABEL_Password</label>
+              <label htmlFor="password" className="block text-sm font-medium text-neutral-700 mb-1">Password</label>
               <input
                 type="password"
                 id="password"
@@ -156,7 +156,7 @@ const LoginScreen: React.FC = () => {
             disabled={isLoading}
             className="w-full py-3 px-5 bg-gradient-deep-blue hover:opacity-90 text-white font-semibold rounded-md shadow-md hover:shadow-lg disabled:bg-neutral-400 disabled:opacity-70 transition-all duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-light focus:ring-offset-2 text-sm sm:text-base" /* Changed to gradient, adjusted hover */
           >
-            {isLoading ? 'Processing...' : (isForgotPassword ? 'BM_LABEL_SendResetLink' : (isSignUp ? 'BM_LABEL_SignUp' : 'BM_LABEL_SignIn'))}
+            {isLoading ? 'Processing...' : (isForgotPassword ? 'SendResetLink' : (isSignUp ? 'SignUp' : 'SignIn'))}
           </button>
         </form>
 
@@ -184,7 +184,7 @@ const LoginScreen: React.FC = () => {
                 <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
                 <path d="M1 1h22v22H1z" fill="none"/>
               </svg>
-              BM_LABEL_SignInWithGoogle
+              SignInWithGoogle
             </button>
           </>
         )}
@@ -199,7 +199,7 @@ const LoginScreen: React.FC = () => {
               }}
               className="text-sm text-accent hover:text-accent-dark underline"
             >
-              BM_LABEL_BackToSignIn
+              BackToSignIn
             </button>
           ) : (
             <div className="flex flex-col sm:flex-row justify-between items-center">
@@ -211,7 +211,7 @@ const LoginScreen: React.FC = () => {
                 }}
                 className="text-sm text-accent hover:text-accent-dark underline mb-2 sm:mb-0"
               >
-                {isSignUp ? 'BM_LABEL_AlreadyAccount' : 'BM_LABEL_SignUpPrompt'}
+                {isSignUp ? 'AlreadyAccount' : 'SignUpPrompt'}
               </button>
               {!isSignUp && (
                   <button
@@ -222,7 +222,7 @@ const LoginScreen: React.FC = () => {
                     }}
                     className="text-sm text-accent hover:text-accent-dark underline"
                   >
-                    BM_LABEL_ForgotPassword
+                    ForgotPassword
                   </button>
               )}
             </div>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -47,7 +47,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
   return (
     <div className="max-w-md mx-auto bg-white p-6 sm:p-8 my-8 rounded-xl shadow-2xl border border-neutral-200 text-center space-y-6">
       <div> {/* Group for main profile info + avatar */}
-        <h2 className="text-xl sm:text-2xl font-semibold mb-6 text-primary-dark">BM_LABEL_UserProfileTitle</h2>
+        <h2 className="text-xl sm:text-2xl font-semibold mb-6 text-primary-dark">UserProfileTitle</h2>
 
         {avatarUrl && !avatarLoadError ? (
         <img
@@ -64,7 +64,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
 
       {user.email && (
         <div className="mb-2">
-          <span className="block text-xs text-neutral-500">BM_LABEL_UserProfileEmail</span>
+          <span className="block text-xs text-neutral-500">UserProfileEmail</span>
           <p className="text-neutral-800 text-base sm:text-lg">
             {user.email}
           </p>
@@ -72,7 +72,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
       )}
       {user.last_sign_in_at && (
          <div className="mb-4">
-           <span className="block text-xs text-neutral-500">BM_LABEL_UserProfileLastSignIn</span>
+           <span className="block text-xs text-neutral-500">UserProfileLastSignIn</span>
            <p className="text-neutral-600 text-xs sm:text-sm">
               {new Date(user.last_sign_in_at).toLocaleDateString()}
            </p>
@@ -96,17 +96,17 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
               }}
               className="w-full sm:w-auto bg-primary hover:bg-primary-dark text-white font-semibold py-2 px-4 rounded-md shadow-md hover:shadow-lg transition-all duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-light focus:ring-offset-2 text-sm sm:text-base" /* Corrected padding */
             >
-              BM_LABEL_ChangePasswordTitle
+              ChangePasswordTitle
             </button>
           ) : (
             <form onSubmit={async (e) => {
               e.preventDefault();
               if (newPassword !== confirmNewPassword) {
-                setPasswordChangeError("BM_ERROR_PasswordsDoNotMatch");
+                setPasswordChangeError("PasswordsDoNotMatch");
                 return;
               }
               if (newPassword.length < 6) {
-                setPasswordChangeError("BM_ERROR_PasswordTooShort");
+                setPasswordChangeError("PasswordTooShort");
                 return;
               }
               setIsUpdatingPassword(true);
@@ -115,20 +115,20 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
               try {
                 const { error } = await supabase.auth.updateUser({ password: newPassword });
                 if (error) throw error;
-                setPasswordChangeMessage("BM_SUCCESS_PasswordUpdated");
+                setPasswordChangeMessage("PasswordUpdated");
                 setNewPassword('');
                 setConfirmNewPassword('');
                 setIsChangingPassword(false); // Hide form on success
               } catch (e: any) {
-                setPasswordChangeError(e.message || "BM_ERROR_FailedToUpdatePassword");
+                setPasswordChangeError(e.message || "FailedToUpdatePassword");
               } finally {
                 setIsUpdatingPassword(false);
               }
             }}>
-              <h3 className="text-lg sm:text-xl font-semibold mb-4 text-primary-dark">BM_LABEL_ChangePasswordTitle</h3>
+              <h3 className="text-lg sm:text-xl font-semibold mb-4 text-primary-dark">ChangePasswordTitle</h3>
               <div className="space-y-4">
                 <div>
-                  <label htmlFor="newPassword" className="block text-sm font-medium text-neutral-700 mb-1 text-left">BM_LABEL_NewPassword</label>
+                  <label htmlFor="newPassword" className="block text-sm font-medium text-neutral-700 mb-1 text-left">NewPassword</label>
                 <input
                   type="password"
                   id="newPassword"
@@ -137,11 +137,11 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
                   required
                   minLength={6}
                   className="w-full px-4 py-3 border border-neutral-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-shadow duration-150"
-                  placeholder="BM_PLACEHOLDER_EnterNewPassword"
+                  placeholder="EnterNewPassword"
                 />
               </div>
               <div> {/* Removed mb-4 from here, space-y-4 on parent handles it */}
-                <label htmlFor="confirmNewPassword" className="block text-sm font-medium text-neutral-700 mb-1 text-left">BM_LABEL_ConfirmNewPassword</label>
+                <label htmlFor="confirmNewPassword" className="block text-sm font-medium text-neutral-700 mb-1 text-left">ConfirmNewPassword</label>
                 <input
                   type="password"
                   id="confirmNewPassword"
@@ -150,7 +150,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
                   required
                   minLength={6}
                   className="w-full px-4 py-3 border border-neutral-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-shadow duration-150"
-                  placeholder="BM_PLACEHOLDER_ConfirmNewPassword"
+                  placeholder="ConfirmNewPassword"
                 />
               </div>
               </div> {/* Closing div for space-y-4 that wraps the input fields */}
@@ -162,7 +162,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
                   disabled={isUpdatingPassword}
                   className="w-full sm:flex-1 bg-gradient-deep-blue hover:opacity-90 text-white font-semibold py-2 px-5 rounded-md shadow-md hover:shadow-lg disabled:bg-neutral-400 disabled:opacity-70 transition-all duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-light focus:ring-offset-2 text-sm sm:text-base" /* Corrected py-2.5 to py-2 */
                 >
-                  {isUpdatingPassword ? 'BM_LABEL_UpdatingPassword' : 'BM_LABEL_UpdatePassword'}
+                  {isUpdatingPassword ? 'UpdatingPassword' : 'UpdatePassword'}
                 </button>
                 <button
                   type="button"
@@ -176,7 +176,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
                   disabled={isUpdatingPassword}
                   className="w-full sm:flex-1 bg-neutral-600 hover:bg-neutral-700 text-white font-semibold py-2 px-5 rounded-md shadow-md hover:shadow-lg transition-all duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-neutral-400 focus:ring-offset-2 text-sm sm:text-base" /* Corrected py-2.5 to py-2 */
                 >
-                  BM_LABEL_Cancel
+                  Cancel
                 </button>
               </div>
             </form>
@@ -190,7 +190,7 @@ const UserProfile: React.FC<UserProfileProps> = ({ user }) => {
           onClick={handleSignOut}
           className="w-full sm:w-auto bg-accent hover:bg-accent-dark text-white font-semibold py-2 px-5 rounded-md shadow-md hover:shadow-lg transition-all duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-accent-light focus:ring-offset-2 text-sm sm:text-base" /* Corrected py-2.5 to py-2 */
         >
-          BM_LABEL_SignOut
+          SignOut
         </button>
       </div>
     </div>


### PR DESCRIPTION
I've removed the "BM_LABEL_" and "BM_PLACEHOLDER_" prefixes from various text elements and placeholders within the application's UI components. This change cleans up the displayed text in your UI, making it more user-friendly.

Affected files:
- src/App.tsx
- src/components/LoginScreen.tsx
- src/components/UserProfile.tsx

The prefixes were removed from navigation links, page titles, button texts, input labels, placeholders, and informational messages. The resulting text is either directly suitable for display or can serve as a clean key for internationalization libraries.